### PR TITLE
카카오페이 결제 API

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,21 +1,29 @@
 require("dotenv").config();
+
 const express = require("express");
 const morgan = require("morgan");
 const cors = require("cors");
 
-const { sqlDataSource } = require("./src/models/data-source");
 const { router } = require("./src/routes");
-const { globalErrorHandler } = require("./src/utils/erros");
+const { globalErrorHandler } = require("./src/utils/errors");
+const { sqlDataSource } = require("./src/models/data-source");
 const app = express();
 
 app.use(express.json());
 app.use(cors());
 app.use(morgan("dev"));
-
 app.use(router);
 app.use(globalErrorHandler);
 
 const PORT = 3000;
+
+const start = async () => {
+  app.listen(PORT, () => console.log(`server is listening on ${PORT}`));
+};
+
+app.get("/ping", (req, res) => {
+  return res.status(200).json({ message: "pong" });
+});
 
 sqlDataSource
   .initialize()
@@ -25,12 +33,5 @@ sqlDataSource
   .catch((err) => {
     console.log("Error during Data Source initialization", err);
   });
-
-const start = async () => {
-  app.listen(PORT, () => console.log(`server is listening on ${PORT}`));
-};
-app.get("/ping", (req, res) => {
-  return res.status(200).json({ message: "pong" });
-});
 
 start();

--- a/db/migrations/20221205074548_create_orderStatus_table.sql
+++ b/db/migrations/20221205074548_create_orderStatus_table.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+CREATE TABLE orderStatus
+(
+    `id`              int    NOT NULL    AUTO_INCREMENT, 
+    `name`            varchar(45)    NOT NULL,
+    PRIMARY KEY (id)
+);
+
+-- migrate:down
+DROP TABLE orderStatus

--- a/db/migrations/20221205074654_create_orders_table.sql
+++ b/db/migrations/20221205074654_create_orders_table.sql
@@ -1,0 +1,17 @@
+-- migrate:up
+CREATE TABLE orders
+(
+    `id`              int    NOT NULL    AUTO_INCREMENT, 
+    `tid`             varchar(45)    NOT NULL, 
+    `totalPrice`      decimal(8,2)    NOT NULL, 
+    `user_id`         int    NOT NULL, 
+    `orderStatus_id`  int    NOT NULL, 
+    PRIMARY KEY (id),
+    CONSTRAINT  FOREIGN KEY (user_id)
+        REFERENCES users (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    CONSTRAINT  FOREIGN KEY (orderStatus_id)
+        REFERENCES orderStatus (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);
+
+-- migrate:down
+DROP TABLE orders

--- a/db/migrations/20221205091317_create_movieOptions_seats_orders_table.sql
+++ b/db/migrations/20221205091317_create_movieOptions_seats_orders_table.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+CREATE TABLE movieOptions_seats_orders
+(
+    `id`              int    NOT NULL    AUTO_INCREMENT, 
+    `movieOptions_seat_id`  int    NOT NULL, 
+    `order_id`         int    NOT NULL, 
+    PRIMARY KEY (id),
+    CONSTRAINT  FOREIGN KEY (movieOptions_seat_id)
+        REFERENCES movieOptions_seats (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);
+
+-- migrate:down
+DROP TABLE movieOptions_seats_orders

--- a/db/migrations/20221205121020_alter_order_table.sql
+++ b/db/migrations/20221205121020_alter_order_table.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+ALTER TABLE orders
+  ADD COLUMN created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
+
+-- migrate:down
+DROP TABLE orders

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.2.0",
         "bcrypt": "^5.1.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
@@ -168,6 +169,34 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.0.tgz",
+      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -419,6 +448,17 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -491,6 +531,14 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -642,6 +690,25 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/forwarded": {
@@ -1386,6 +1453,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -2098,6 +2170,33 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.0.tgz",
+      "integrity": "sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2276,6 +2375,14 @@
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2330,6 +2437,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -2450,6 +2562,11 @@
         "statuses": "2.0.1",
         "unpipe": "~1.0.0"
       }
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "forwarded": {
       "version": "0.2.0",
@@ -3019,6 +3136,11 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/wecode-bootcamp-korea/39-2nd-CGW-backend#readme",
   "dependencies": {
+    "axios": "^1.2.0",
     "bcrypt": "^5.1.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",

--- a/src/controllers/kakao.controller.js
+++ b/src/controllers/kakao.controller.js
@@ -1,0 +1,29 @@
+const kakaoService = require("../services/kakao.service");
+const { catchAsync } = require("../utils/errors");
+
+const paymentReady = catchAsync(async (req, res) => {
+  const {item_name, quantity, total_amount, tax_free_amount } = req.body;
+
+  if (!item_name || !quantity || !total_amount || !tax_free_amount) {
+    errorHandler("KEY_ERROR", 400)
+  };
+
+  const response = await kakaoService.readyRespose(item_name, quantity, total_amount, tax_free_amount);
+
+  return res.status(200).json(response);
+});
+
+
+const approval = catchAsync(async (req, res) => {
+  const {userId, totalPrice, movieOptionsSeatId, pgToken, tid} = req.body;
+
+  if (!userId || !totalPrice || !movieOptionsSeatId || !pgToken || !tid ) {
+    errorHandler("KEY_ERROR", 400)
+  };
+
+  const result = await kakaoService.approval(userId, totalPrice, movieOptionsSeatId, pgToken, tid);
+
+  await res.status(200).json({ message: result });
+});
+
+module.exports = { paymentReady, approval };

--- a/src/models/order.dao.js
+++ b/src/models/order.dao.js
@@ -1,0 +1,49 @@
+const { sqlDataSource } = require("./data-source");
+
+const createOrders = async (data, userId, totalPrice, movieOptionsSeatId, tid) => {
+  await sqlDataSource.manager.transaction(async (transactionalEntityManager) => {
+    await transactionalEntityManager.query(
+      `    
+      INSERT INTO orders (
+        tid,
+        totalPrice,
+        user_id,
+        orderStatus_id
+      ) VALUES (
+        ?,
+        ?,
+        ?,
+        1
+      );
+      `,
+      [tid, totalPrice, userId]
+    );
+    
+    const [getOrderId] = await transactionalEntityManager.query(
+      `
+      SELECT id
+        FROM orders o
+        WHERE o.user_id = ?
+        ORDER BY created_at DESC LIMIT 1;
+      `,
+      [userId]
+      );
+
+    await movieOptionsSeatId.map(seats => {
+      transactionalEntityManager.query(
+        `
+        INSERT INTO movieOptions_seats_orders (
+          order_id,
+          movieOptions_seat_id
+        ) VALUES (
+          ?,
+          ?
+        );
+        `,
+        [ getOrderId["id"], seats ]
+      );
+    });
+  });
+};
+
+module.exports = { createOrders };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,7 @@
 const express = require("express");
-
 const router = express.Router();
+const kakaoRouter = require("./kakao.router");
+
+router.use("/kakaoPayment", kakaoRouter.router);
 
 module.exports = { router };

--- a/src/routes/kakao.router.js
+++ b/src/routes/kakao.router.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const kakaoController = require("../controllers/kakao.controller");
+
+router.post("", kakaoController.paymentReady);
+router.post("/approval", kakaoController.approval);
+
+
+module.exports = { router };

--- a/src/services/kakao.service.js
+++ b/src/services/kakao.service.js
@@ -1,0 +1,76 @@
+const axios = require('axios').default;
+const orderDao = require("../models/order.dao")
+
+async function readyRespose(item_name, quantity, total_amount, tax_free_amount) {
+  try {
+    const APP_ADMIN_KEY = process.env.APP_ADMIN_KEY;
+
+    const params = {
+      cid: "TC0ONETIME",
+      partner_order_id: "partner_order_id",
+      partner_user_id: "partner_user_id",
+      item_name: item_name,
+      quantity: quantity,
+      total_amount: total_amount,
+      tax_free_amount: tax_free_amount,
+      approval_url: "http://127.0.0.1:3000",
+      cancel_url: "http://10.58.52.51:3000/kakaoPayment/approval",
+      fail_url: "http://10.58.52.51:3000/kakaoPayment/approval",
+    };
+
+    const headers = {
+      headers: {
+        Authorization: `KakaoAK ${APP_ADMIN_KEY}`,
+        "Content-type": "application/x-www-form-urlencoded;charser=-utf-8",
+      },
+    };
+  
+    const response = await axios.post(
+      "https://kapi.kakao.com/v1/payment/ready",
+      params,
+      headers
+    );
+  
+    const { tid, next_redirect_pc_url } = response.data;
+    return { tid, next_redirect_pc_url };
+
+  } catch (error) {
+    errorHandler("KAKAO_SERVER_ERROR", 400)
+  }
+};
+
+async function approval(userId, totalPrice, movieOptionsSeatId, pgToken, tid) {
+  try{
+    const APP_ADMIN_KEY = process.env.APP_ADMIN_KEY;
+    const params = {
+      cid: "TC0ONETIME",
+      tid: tid,
+      partner_order_id: "partner_order_id",
+      partner_user_id: "partner_user_id",
+      pg_token: pgToken,
+    };
+    const headers = {
+      headers: {
+        Authorization: `KakaoAK ${APP_ADMIN_KEY}`,
+        "Content-type": "application/x-www-form-urlencoded;charser=-utf-8",
+      }
+    };
+
+    const response = await axios.post('https://kapi.kakao.com/v1/payment/approve',
+    params,
+    headers
+    );
+
+    if (response.status == 200){
+      const data = response.data; // 추후 사용할 가능성을 고려해서 넣어두었습니다.
+      await orderDao.createOrders(data, userId, totalPrice, movieOptionsSeatId, tid);
+    }
+
+    return "PAYMENT_SUCCESS"
+
+  } catch (error){
+    errorHandler("KAKAO_SERVER_ERROR", 400)
+  }
+}
+
+module.exports = { readyRespose, approval };

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -12,4 +12,11 @@ const globalErrorHandler = (err, req, res, next) => {
   res.status(err.statusCode).json({ message: err.message });
 };
 
-module.exports = { catchAsync, globalErrorHandler };
+const errorHandler = (errorMessage, errorCode) => {
+  const err = new Error(errorMessage);
+  err.statusCode = errorCode;
+  throw err;
+}
+
+
+module.exports = { catchAsync, globalErrorHandler, errorHandler };


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 데이터베이스 작업
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표

- 카카오 결제 준비 API 구현
- 카카오 결제 승인 API 구현
- https://documenter.getpostman.com/view/24100970/2s8YzMYkKS [API 명세]

<br />

## :: 구현 사항 설명

- [결제 준비] 카카오페이 결제를 시작하기 위해 상세 정보를 프론트로부터 받아 카카오페이 서버에 전달하고 결제 고유 번호(TID)와 Redirect URL을 받도 프론트에 전달합니다.

- [결제 승인] 프론트로부터 userId, totalPrice, movieOptionsSeatId, pgToken, tid를 받아 카카오 서버에 전달하여 결제 승인을 받습니다.

- 결제가 승인되면 orders table과 movieOptions_seats_orders table에 데이터를 추가합니다.

- 에러헨들링 리펙터링 (errorHandler함수 모듈화)

<br />

## :: 테스트 결과 이미지

결제 내역에 대한 데이터를 관리하기 위해  orders table, orderStatus table 과 movieOptions_seats_orders table을 추가했습니다.

![Screen Shot 2022-12-05 at 9 50 45 PM](https://user-images.githubusercontent.com/100187797/205650187-f752629d-18a7-495a-9541-aade441d4dc6.png)

경제가 승인 완료 후 테이블에 데이터가 추가된 결과 입니다. orderStatus_id 1은 payment completed 입니다.
![Screen Shot 2022-12-05 at 9 59 30 PM](https://user-images.githubusercontent.com/100187797/205650204-3ba892ec-764a-4fdc-9963-b3c363127589.png)


<br />

## :: 기타 질문 및 특이 사항

- 보통 [결제 준비], [결제 진행]은 프론트에서 진행하지만 이번 프로젝트에서는 학습을 위해 백에서 모두 진행해봤습니다.
- Test 코드는 징행중입니다. 추후에 테스트 코드를 포함에서 다시 올리겠습니다.